### PR TITLE
Add Qwen3-235B-A22B Thinking Model to LLM Data

### DIFF
--- a/src/data/llm-data.json
+++ b/src/data/llm-data.json
@@ -436,6 +436,8 @@
     "outputPrice": 0.312,
     "maxOutputTokens": 82,
     "webdevElo": 1189.67,
+    "AAIndex": 64,
+    "costAAIndex": 892,
     "modelUrl": "https://qwenlm.github.io/blog/qwen3/",
     "pricingUrl": "https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507",
     "notes": "Thinking-only MoE model (22B active) with enforced </think> reasoning blocks, long context (262k) and high token output (up to ~82k)."

--- a/src/data/llm-data.json
+++ b/src/data/llm-data.json
@@ -436,6 +436,8 @@
     "outputPrice": 0.312,
     "maxOutputTokens": 82,
     "webdevElo": 1189.67,
+    "aiderBench": 59.6,
+    "simpleBench": 31.0,
     "AAIndex": 64,
     "costAAIndex": 892,
     "modelUrl": "https://qwenlm.github.io/blog/qwen3/",

--- a/src/data/llm-data.json
+++ b/src/data/llm-data.json
@@ -435,6 +435,7 @@
     "inputPrice": 0.078,
     "outputPrice": 0.312,
     "maxOutputTokens": 82,
+    "webdevElo": 1189.67,
     "modelUrl": "https://qwenlm.github.io/blog/qwen3/",
     "pricingUrl": "https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507",
     "notes": "Thinking-only MoE model (22B active) with enforced </think> reasoning blocks, long context (262k) and high token output (up to ~82k)."

--- a/src/data/llm-data.json
+++ b/src/data/llm-data.json
@@ -424,5 +424,19 @@
     "modelUrl": "https://ai.meta.com/blog/llama-4-multimodal-intelligence/",
     "pricingUrl": "https://openrouter.ai/meta-llama/llama-4-maverick",
     "costAAIndex": 10
+  },
+  {
+    "model": "Qwen3-235B-A22B-Thinking-2507",
+    "provider": "OpenRouter",
+    "developer": "Qwen",
+    "context": 262,
+    "hasReasoning": true,
+    "toolUse": true,
+    "inputPrice": 0.078,
+    "outputPrice": 0.312,
+    "maxOutputTokens": 82,
+    "modelUrl": "https://qwenlm.github.io/blog/qwen3/",
+    "pricingUrl": "https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507",
+    "notes": "Thinking-only MoE model (22B active) with enforced </think> reasoning blocks, long context (262k) and high token output (up to ~82k)."
   }
 ]

--- a/src/data/llm-data.json
+++ b/src/data/llm-data.json
@@ -438,6 +438,7 @@
     "webdevElo": 1189.67,
     "aiderBench": 59.6,
     "simpleBench": 31.0,
+    "fictionLiveBench": 77.8,
     "AAIndex": 64,
     "costAAIndex": 892,
     "modelUrl": "https://qwenlm.github.io/blog/qwen3/",


### PR DESCRIPTION
This PR adds the Qwen3-235B-A22B-Thinking-2507 model to our dataset. This high-performance, open-weight Mixture-of-Experts (MoE) model is optimized for complex reasoning tasks and features a context capacity of 262,144 tokens. This addition includes detailed pricing information and specifications, such as its instruction-tuning capabilities and enhanced structured reasoning performance. The new entry ensures users can access comprehensive information about this advanced model, empowering them in their development and research efforts.

---

> This pull request was co-created with Cosine Genie

Original Task: [ai-pricing/da6ff0cdoi4a](https://cosine.sh/0o0rnw3vmmyg/ai-pricing/task/da6ff0cdoi4a)
Author: wiegerwolf
