### PR TITLE
Remove footer social links and update Claude Sonnet 4.6 metrics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ export default function App() {
         <DataTable columns={columns(llmData)} data={llmData} />
       </main>
       <footer className="text-xs text-gray-500 py-4 px-4 flex items-center justify-between border-t">
-        <span>Last updated: Feb 12, 2026</span>
+        <span>Last updated: Feb 18, 2026</span>
         <span>
           Found a mistake? Submit a PR at{" "}
           <a

--- a/src/data/llm-data.json
+++ b/src/data/llm-data.json
@@ -158,6 +158,26 @@
     "fictionLiveBench": 88.9
   },
   {
+    "model": "Claude Sonnet 4.6",
+    "developer": "Anthropic",
+    "modelUrl": "https://www.anthropic.com/news/claude-sonnet-4-6",
+    "context": 1000,
+    "maxOutputTokens": 128,
+    "inputPrice": 3,
+    "outputPrice": 15,
+    "hasReasoning": true,
+    "toolUse": true,
+    "hasVision": true,
+    "AAIndex": 51,
+    "SWEBench": 79.6,
+    "GPQAdiamond": 89.9,
+    "HumLastExam": 33.2,
+    "ARCAGI2": 58.3,
+    "costAAIndex": 2089,
+    "tokenUseAAIndex": 74,
+    "VendingBench": 7204.14
+  },
+  {
     "model": "Claude Haiku 4.5",
     "developer": "Anthropic",
     "snitchBench": 0.0,


### PR DESCRIPTION
### Motivation
- Remove the extra "Stay connected" social-links block from the footer to keep the UI minimal while preserving the repo link and last-updated text.
- Add the additional performance and cost metrics for `Claude Sonnet 4.6` so the dataset reflects the provided benchmark and cost numbers.

### Description
- Removed the footer social-links block from `src/App.tsx`, leaving the repo link and `Last updated` text intact.
- Added/updated fields for `Claude Sonnet 4.6` in `src/data/llm-data.json`: `costAAIndex` = `2089`, `tokenUseAAIndex` = `74`, and `VendingBench` = `7204.14`.
- Kept the previously updated `Last updated: Feb 18, 2026` footer text.

### Testing
- Ran `bun run build` which completed successfully and produced a production build.
- Ran `bun run lint` which failed due to a pre-existing `@typescript-eslint/no-explicit-any` error in `src/utils/colorScale.ts` unrelated to these changes.
- Started the dev server and executed a Playwright script to capture a screenshot of the footer for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699598c693dc832f9bce2586e10a1efa)